### PR TITLE
Bugfix for "null" chip when bolded part of an autosuggest is clicked

### DIFF
--- a/dist/mdl-chips-input.js
+++ b/dist/mdl-chips-input.js
@@ -153,7 +153,7 @@
     };
 
     MaterialChipInput.prototype.clickedResult_ = function(event) {
-        this.addChip_(event.target.getAttribute('data-value'));
+        this.addChip_(event.target.closest('li').getAttribute('data-value'));
         this.clearResults_();
         this.input_.value = '';
     };


### PR DESCRIPTION
PR fixes this problem:

Click here:
![screenshot from 2018-10-04 22-06-01](https://user-images.githubusercontent.com/1786477/46505801-19431680-c7e7-11e8-9e90-1c46255f9bfa.png)

and you get this:
![screenshot from 2018-10-04 22-06-03](https://user-images.githubusercontent.com/1786477/46505818-26f89c00-c7e7-11e8-803c-df3cb9338a6b.png)
